### PR TITLE
Add test asserting that get_values works by itself

### DIFF
--- a/test/test_config.py
+++ b/test/test_config.py
@@ -398,6 +398,17 @@ class TestBase(TestCase):
         with self.assertRaises(cp.NoOptionError):
             cr.get_value("color", "ui")
 
+    def test_get_values_works_without_requiring_any_other_calls_first(self):
+        file_obj = self._to_memcache(fixture_path("git_config_multiple"))
+        cr = GitConfigParser(file_obj, read_only=True)
+        self.assertEqual(cr.get_values("section0", "option0"), ["value0"])
+        file_obj.seek(0)
+        cr = GitConfigParser(file_obj, read_only=True)
+        self.assertEqual(cr.get_values("section1", "option1"), ["value1a", "value1b"])
+        file_obj.seek(0)
+        cr = GitConfigParser(file_obj, read_only=True)
+        self.assertEqual(cr.get_values("section1", "other_option1"), ["other_value1"])
+
     def test_multiple_values(self):
         file_obj = self._to_memcache(fixture_path("git_config_multiple"))
         with GitConfigParser(file_obj, read_only=False) as cw:


### PR DESCRIPTION
As described in #1534, this test will fail in main with a `KeyError` about a missing section name even though the named sections do exist within the config file.

This test will pass in the branch associated with #1535. This test should keep the improved behavior healthy as the code evolves by preventing future developers from removing the eager loading of sections within `get_values()`.